### PR TITLE
Set the bg for a Folder

### DIFF
--- a/src/portfolio/ui/components/browser.cljs
+++ b/src/portfolio/ui/components/browser.cljs
@@ -28,7 +28,7 @@
 
 (d/defcomponent Folder [{:keys [title illustration actions items context]}]
   (let [left-padding (+ 8 (get-context-offset context :folder))]
-    [:div {:style {}}
+    [:div {:style {:background "var(--bg)"}}
      [:h2.h4
       {:on-click actions
        :style {:background "var(--folder-bg)"


### PR DESCRIPTION
On default light-mode, the Folder/Package views from the Compare
selector are completely unreadable.

This doesn't seem to adversely affect anywhere else, so this would be a nice one to get in